### PR TITLE
Bump SK to v1.3.0 + Planners

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,11 +17,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.2.0-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.2.0-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.3.0-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.3.0-preview" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.6.6" />
     <PackageVersion Include="YamlDotNet" Version="15.1.0" />


### PR DESCRIPTION
## Description

What's new?

- Bump Semantic Kernel to v1.3.0
- Bump SK planners to v1.3.0-preview

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other