### PR TITLE
Add Google search API key option to autogen

### DIFF
--- a/samples/02-autogen/02-autogen.csproj
+++ b/samples/02-autogen/02-autogen.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     <PackageReference Include="FinancialFormulas" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.5.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.5.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.1-preview.0.32" />

--- a/samples/02-autogen/appsettings.json
+++ b/samples/02-autogen/appsettings.json
@@ -1,5 +1,25 @@
 {
-  "AzureOpenAIEndpoint": "",
-  "AzureOpenAIAPIKey": "",
-  "OllamaEndpoint": ""
+  "AzureOpenAIEndpoint": "https://cgiaura-openai-trainning.openai.azure.com/",
+  "AzureOpenAIAPIKey": "2b30e6606d7d43ecbd74ae52d2dd1a6e",
+  "OllamaEndpoint": "http://localhost:11434",
+  "AzureOpenAIGPT4DeploymentName": "gpt-4-1106-preview",
+  "AzureOpenAIGPT35DeploymentName": "gpt-35-turbo-16k-0613",
+  "CodeInterpreter": {
+    "DockerEndpoint": "npipe://./pipe/docker_engine",
+    "DockerImage": "python:3-alpine",
+    "OutputFilePath": "<YourOutpurFilePath>",
+    "GoogleSearchAPIKey": "<YourGoogleApiKey>",
+    "GoogleSearchEngineId": "<YourGoogleSearchEngineId>"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace"
+    },
+    "Debug": {
+      "LogLevel": {
+        "Default": "Trace",
+        "SemanticKernel.Assistants.*": "Trace"
+      }
+    }
+  }
 }

--- a/src/Assistants.AutoGen/Assistants/AssistantAgent.yaml
+++ b/src/Assistants.AutoGen/Assistants/AssistantAgent.yaml
@@ -15,8 +15,6 @@ instructions: |
     
     If the result indicates there is an error, fix the error and output the code again. Suggest the full code instead of partial code or code changes. If the error can't be fixed or if the task is not solved even after the code is executed successfully, analyze the problem, revisit your assumption, collect additional info you need, and think of a different approach to try.
     
-    Don't ever assume that you can't access the WEB, using CodeInterpreter agent, you'll be able to connect to the Internet.
-
     When you find an answer, verify the answer carefully. Include verifiable evidence in your response if possible.
     Reply "TERMINATE" in the end when everything is done.
 

--- a/src/Assistants.AutoGen/Assistants/CodeInterpreter.yaml
+++ b/src/Assistants.AutoGen/Assistants/CodeInterpreter.yaml
@@ -5,11 +5,8 @@ description: |
     This agent does not store instructions between calls, so you need to provide a complete code file to execute.
 
      ##Important
-     1. You should alway send a full code to execute.
-     2. You should always specify your requirements otherwise the code will fail.
-     3. When you have to generate files as output, be sure to write it to ``/var/app/output/`` directory, this directory is bind to the current directory, so ommit this path when trying to access to it.
-     4. When you provide input files they are binded into ``/var/app/inputs`` directory, so in your code you should use this base path to access to it. 
-     5. Do not provide a relative path, always use full path.
+     - You should alway send a full code to execute.
+     - You should always specify your requirements otherwise the code will fail.     
 instructions: 
 input_parameters: 
      - name: input
@@ -37,7 +34,14 @@ input_parameters:
           This code should be sended like this: 
           ```
           x = 1\r\ny = 2.8\r\nz = 1j\r\n\r\nprint(type(x))\r\nprint(type(y))\r\nprint(type(z))
-          ```         
+          ```
+          
+          ## Tips
+          - When you have to generate files as output, be sure to write it to ``/var/app/output/`` directory, this directory is bind to the current directory, so ommit this path when trying to access to it.
+          - When you provide input files they are binded into ``/var/app/inputs`` directory, so in your code you should use this base path to access to it. 
+          - Do not provide a relative path, always use full path.
+          - When you need to search on Google using REST API, you can use ``GOOGLE_SEARCH_API_KEY`` and ``GOOGLE_SEARCH_ENGINE_ID`` environment variables.
+
      - name: requirements
        is_required: False
        default_value: ""
@@ -47,6 +51,7 @@ input_parameters:
 
           ## Example
           ```
+          requests
           tensorflow
           uvicorn
           fastapi==0.63.0
@@ -74,4 +79,4 @@ execution_settings:
   prompt_settings: 
     temperature: 0.0
     top_p: 1
-    max_tokens: 1000
+    max_tokens: 4096

--- a/src/Assistants.AutoGen/Plugins/CodeInterpretionPlugin.cs
+++ b/src/Assistants.AutoGen/Plugins/CodeInterpretionPlugin.cs
@@ -74,7 +74,7 @@ public class CodeInterpretionPlugin
 
             this.PrepareOutputFiles(outputDirectory, arguments);
 
-            return result;
+            return result!;
         }
         finally
         {
@@ -146,7 +146,11 @@ public class CodeInterpretionPlugin
             NetworkDisabled = false,
             HostConfig = new HostConfig()
             {
-                Binds = inputBindings
+                Binds = inputBindings               
+            },
+            Env = new[] { 
+                $"GOOGLE_SEARCH_API_KEY={this._options.GoogleSearchAPIKey}",
+                $"GOOGLE_SEARCH_ENGINE_ID={this._options.GoogleSearchEngineId}"
             }
         };
 

--- a/src/Assistants.AutoGen/Plugins/CodeInterpretionPluginOptions.cs
+++ b/src/Assistants.AutoGen/Plugins/CodeInterpretionPluginOptions.cs
@@ -9,4 +9,8 @@ public class CodeInterpretionPluginOptions
     public string DockerImage { get; set; } = "python:3-alpine";
 
     public string OutputFilePath { get; set; } = ".";
+
+    public string GoogleSearchAPIKey { get; set; } = string.Empty;
+
+    public string GoogleSearchEngineId { get; set; } = string.Empty;
 }

--- a/src/Assistants/Extensions/KernelExtensions.cs
+++ b/src/Assistants/Extensions/KernelExtensions.cs
@@ -30,7 +30,9 @@ public static class KernelExtensions
             {
                 var thread = assistant.CreateThread(args.ToDictionary());
 
-                return await thread.InvokeAsync(input).ConfigureAwait(false);
+                var message =  await thread.InvokeAsync(input).ConfigureAwait(false);
+
+                return message.Content!;
             },
             functionName: "Ask",
             description: assistant.Description,

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,16 +7,16 @@
   <ItemGroup>
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0-preview.1.24080.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0-preview.1.24080.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.5.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.5.0" />


### PR DESCRIPTION
## Description

What's new?

- Add Google Search API key and Google Search Engine Id option to Code interpreter and Auto-gen sample

Now you By adding your settings, you can customize how your code interpreter should work. All those settings are set to the docker container running the code interpreter. The Code assistant know that he can use corresponding environment variables when trying to reach Google APIs.

For example: 
``` 
"CodeInterpreter": {
  "DockerEndpoint": "npipe://./pipe/docker_engine",
  "DockerImage": "python:3-alpine",
  "OutputFilePath": "<YourOutpurFilePath>",
  "GoogleSearchAPIKey": "<YourGoogleApiKey>",
  "GoogleSearchEngineId": "<YourGoogleSearchEngineId>"
},
```

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other