### PR TITLE
Bump Microsoft.SemanticKernel.Planners

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.13.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.13.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.13.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.10.0-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.10.0-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.13.0-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.13.0-preview" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.8.0" />
     <PackageVersion Include="YamlDotNet" Version="15.1.4" />


### PR DESCRIPTION
## Description

What's new?

- Bump Microsoft.SemanticKernel.Planners.Handlebars to [1.13.0-preview](https://www.nuget.org/packages/Microsoft.SemanticKernel.Planners.Handlebars/1.13.0-preview)
- Bump Microsoft.SemanticKernel.Planners.OpenAI to [1.13.0-preview](https://www.nuget.org/packages/Microsoft.SemanticKernel.Planners.OpenAI/1.13.0-preview)

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other